### PR TITLE
Lint free or die

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,8 @@
     "extends": "airbnb",
     "rules": {
         "no-console": 0
+    },
+    "env": {
+        "jasmine": true
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,12 @@
 {
     "extends": "airbnb",
     "rules": {
-        "no-console": 0
+        "no-console": 0,
+        "no-var": 0,
+        "prefer-arrow-callback": 0,
+        "prefer-template": 0,
+        "func-names": 0,
+        "object-shorthand": 0
     },
     "env": {
         "jasmine": true

--- a/lib/pc.js
+++ b/lib/pc.js
@@ -10,7 +10,7 @@ function PC(options) {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   }
   if (options.files === undefined || options.jenkinsServer === undefined) {
-    throw new Error('Must pass options object to constructor with keys "files" and "jenkinsServer" defined');
+    throw new Error('Must pass options object with keys "files" and "jenkinsServer"');
   }
   this.files = options.files;
   this.jenkins = jenkins({

--- a/lib/pc.js
+++ b/lib/pc.js
@@ -1,80 +1,80 @@
 var jenkins = require('jenkins'),
-    Promise = require('bluebird'),
-    fs = require('fs'),
-    chalk = require('chalk');
+  Promise = require('bluebird'),
+  fs = require('fs'),
+  chalk = require('chalk');
 
 Promise.promisifyAll(fs);
 
 function PC(options) {
-    if(options.ignoreSSL){
-        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  if (options.ignoreSSL) {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
     }
-    if(options.files === undefined || options.jenkinsServer === undefined){
-        throw new Error('Must pass options object to constructor with keys "files" and "jenkinsServer" defined');
+  if (options.files === undefined || options.jenkinsServer === undefined) {
+      throw new Error('Must pass options object to constructor with keys "files" and "jenkinsServer" defined');
     }
-    this.files = options.files;
-    this.jenkins = jenkins({
-        baseUrl: options.jenkinsServer,
-        promisify: true
+  this.files = options.files;
+  this.jenkins = jenkins({
+      baseUrl: options.jenkinsServer,
+      promisify: true
     });
 }
 
-PC.prototype.unload = function(){
-    var self = this;
-    return Promise.all([
-        this._getJobs(),
-        this._getViews()
-    ]).then(function(){
-        if(self.successfullyProcessedCount){
-            console.log(chalk.green(self.successfullyProcessedCount) + ' jobs succesfully saved.');
+PC.prototype.unload = function () {
+  var self = this;
+  return Promise.all([
+      this._getJobs(),
+      this._getViews()
+    ]).then(function () {
+      if (self.successfullyProcessedCount) {
+          console.log(chalk.green(self.successfullyProcessedCount) + ' jobs succesfully saved.');
         }
-        if(self.failedToProcessCount){
-            console.log(chalk.red(self.failedToProcessCount) + ' jobs could not be saved.');
+      if (self.failedToProcessCount) {
+          console.log(chalk.red(self.failedToProcessCount) + ' jobs could not be saved.');
         }
-        console.log(chalk.yellow('Done!\n'));
+      console.log(chalk.yellow('Done!\n'));
     });
 };
 
-PC.prototype.load = function(){
+PC.prototype.load = function () {
     // TODO: Implement this.
 };
 
-PC.prototype._getJobs = function(){
-    var self = this;
-    console.log('Fetching job list from Jenkins...');
-    return this.jenkins.job.list().then(function(jobList) {
-        self.jobCount = jobList.length;
-        self.jobProcessedCount = 0;
-        self.successfullyProcessedCount = 0;
-        self.failedToProcessCount = 0;
-        return Promise.map(jobList, function(job){
-            return self._getJobXML(job.name);
+PC.prototype._getJobs = function () {
+  var self = this;
+  console.log('Fetching job list from Jenkins...');
+  return this.jenkins.job.list().then(function (jobList) {
+      self.jobCount = jobList.length;
+      self.jobProcessedCount = 0;
+      self.successfullyProcessedCount = 0;
+      self.failedToProcessCount = 0;
+      return Promise.map(jobList, function (job) {
+          return self._getJobXML(job.name);
         });
     });
 };
 
-PC.prototype._getJobXML = function(jobName){
-    var self = this,
-        filePath = self.files + '/' + jobName + '.xml';
-        return this.jenkins.job.config(jobName).then(function(xml){
-            return fs.writeFileAsync(filePath, xml);
-        }).then(function(){
-            self.jobProcessedCount++;
-            self.successfullyProcessedCount++;
-            console.log(
-                chalk.green('     ✔ Saved job ['+self.jobProcessedCount+'/'+self.jobCount+'] "') +
+PC.prototype._getJobXML = function (jobName) {
+  var self = this,
+      filePath = self.files + '/' + jobName + '.xml';
+  return this.jenkins.job.config(jobName).then(function (xml) {
+          return fs.writeFileAsync(filePath, xml);
+        }).then(function () {
+          self.jobProcessedCount++;
+          self.successfullyProcessedCount++;
+          console.log(
+                chalk.green('     ✔ Saved job [' + self.jobProcessedCount + '/' + self.jobCount + '] "') +
                     chalk.cyan(jobName) +
                         chalk.green('" to ') +
                             filePath
             );
-        }).catch(function(err){
-            self.jobProcessedCount++;
-            self.failedToProcessCount++;
+        }).catch(function (err) {
+          self.jobProcessedCount++;
+          self.failedToProcessCount++;
 
-            var errMsg = '     ✘ Could not save job [' + self.jobProcessedCount + '/';
-            errMsg+= self.jobCount + '] "';
+          var errMsg = '     ✘ Could not save job [' + self.jobProcessedCount + '/';
+          errMsg += self.jobCount + '] "';
 
-            console.log(
+          console.log(
                 chalk.red(errMsg) +
                     chalk.cyan(jobName) +
                         chalk.red('"\n      Error Message: ' + err.message)
@@ -84,7 +84,7 @@ PC.prototype._getJobXML = function(jobName){
 
 PC.prototype._getViews = function _getViews() {
     // TODO: Implement this
-    return true;
+  return true;
 };
 
 module.exports = PC;

--- a/lib/pc.js
+++ b/lib/pc.js
@@ -1,89 +1,90 @@
-var jenkins = require('jenkins'),
-  Promise = require('bluebird'),
-  fs = require('fs'),
-  chalk = require('chalk');
+var jenkins = require('jenkins');
+var Promise = require('bluebird');
+var fs = require('fs');
+var chalk = require('chalk');
 
 Promise.promisifyAll(fs);
 
 function PC(options) {
   if (options.ignoreSSL) {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-    }
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  }
   if (options.files === undefined || options.jenkinsServer === undefined) {
-      throw new Error('Must pass options object to constructor with keys "files" and "jenkinsServer" defined');
-    }
+    throw new Error('Must pass options object to constructor with keys "files" and "jenkinsServer" defined');
+  }
   this.files = options.files;
   this.jenkins = jenkins({
-      baseUrl: options.jenkinsServer,
-      promisify: true
-    });
+    baseUrl: options.jenkinsServer,
+    promisify: true
+  });
 }
 
 PC.prototype.unload = function () {
   var self = this;
   return Promise.all([
-      this._getJobs(),
-      this._getViews()
-    ]).then(function () {
-      if (self.successfullyProcessedCount) {
-          console.log(chalk.green(self.successfullyProcessedCount) + ' jobs succesfully saved.');
-        }
-      if (self.failedToProcessCount) {
-          console.log(chalk.red(self.failedToProcessCount) + ' jobs could not be saved.');
-        }
-      console.log(chalk.yellow('Done!\n'));
-    });
+    this._getJobs(),
+    this._getViews()
+  ]).then(function () {
+    if (self.successfullyProcessedCount) {
+      console.log(chalk.green(self.successfullyProcessedCount) + ' jobs succesfully saved.');
+    }
+    if (self.failedToProcessCount) {
+      console.log(chalk.red(self.failedToProcessCount) + ' jobs could not be saved.');
+    }
+    console.log(chalk.yellow('Done!\n'));
+  });
 };
 
 PC.prototype.load = function () {
-    // TODO: Implement this.
+  // TODO: Implement this.
 };
 
 PC.prototype._getJobs = function () {
   var self = this;
   console.log('Fetching job list from Jenkins...');
   return this.jenkins.job.list().then(function (jobList) {
-      self.jobCount = jobList.length;
-      self.jobProcessedCount = 0;
-      self.successfullyProcessedCount = 0;
-      self.failedToProcessCount = 0;
-      return Promise.map(jobList, function (job) {
-          return self._getJobXML(job.name);
-        });
+    self.jobCount = jobList.length;
+    self.jobProcessedCount = 0;
+    self.successfullyProcessedCount = 0;
+    self.failedToProcessCount = 0;
+    return Promise.map(jobList, function (job) {
+      return self._getJobXML(job.name);
     });
+  });
 };
 
 PC.prototype._getJobXML = function (jobName) {
-  var self = this,
-      filePath = self.files + '/' + jobName + '.xml';
+  var self = this;
+  var filePath = self.files + '/' + jobName + '.xml';
+
   return this.jenkins.job.config(jobName).then(function (xml) {
-          return fs.writeFileAsync(filePath, xml);
-        }).then(function () {
-          self.jobProcessedCount++;
-          self.successfullyProcessedCount++;
-          console.log(
-                chalk.green('     ✔ Saved job [' + self.jobProcessedCount + '/' + self.jobCount + '] "') +
-                    chalk.cyan(jobName) +
-                        chalk.green('" to ') +
-                            filePath
-            );
-        }).catch(function (err) {
-          self.jobProcessedCount++;
-          self.failedToProcessCount++;
+    return fs.writeFileAsync(filePath, xml);
+  }).then(function () {
+    self.jobProcessedCount++;
+    self.successfullyProcessedCount++;
+    console.log(
+      chalk.green('     ✔ Saved job [' + self.jobProcessedCount + '/' + self.jobCount + '] "') +
+        chalk.cyan(jobName) +
+        chalk.green('" to ') +
+        filePath
+    );
+  }).catch(function (err) {
+    self.jobProcessedCount++;
+    self.failedToProcessCount++;
 
-          var errMsg = '     ✘ Could not save job [' + self.jobProcessedCount + '/';
-          errMsg += self.jobCount + '] "';
+    var errMsg = '     ✘ Could not save job [' + self.jobProcessedCount + '/';
+    errMsg += self.jobCount + '] "';
 
-          console.log(
-                chalk.red(errMsg) +
-                    chalk.cyan(jobName) +
-                        chalk.red('"\n      Error Message: ' + err.message)
-            );
-        });
+    console.log(
+      chalk.red(errMsg) +
+        chalk.cyan(jobName) +
+        chalk.red('"\n      Error Message: ' + err.message)
+    );
+  });
 };
 
 PC.prototype._getViews = function _getViews() {
-    // TODO: Implement this
+  // TODO: Implement this
   return true;
 };
 

--- a/lib/pc.js
+++ b/lib/pc.js
@@ -15,7 +15,7 @@ function PC(options) {
   this.files = options.files;
   this.jenkins = jenkins({
     baseUrl: options.jenkinsServer,
-    promisify: true
+    promisify: true,
   });
 }
 
@@ -23,7 +23,7 @@ PC.prototype.unload = function () {
   var self = this;
   return Promise.all([
     this._getJobs(),
-    this._getViews()
+    this._getViews(),
   ]).then(function () {
     if (self.successfullyProcessedCount) {
       console.log(chalk.green(self.successfullyProcessedCount) + ' jobs succesfully saved.');

--- a/lib/pc.js
+++ b/lib/pc.js
@@ -69,10 +69,11 @@ PC.prototype._getJobXML = function (jobName) {
         filePath
     );
   }).catch(function (err) {
+    var errMsg;
     self.jobProcessedCount++;
     self.failedToProcessCount++;
 
-    var errMsg = '     ✘ Could not save job [' + self.jobProcessedCount + '/';
+    errMsg = '     ✘ Could not save job [' + self.jobProcessedCount + '/';
     errMsg += self.jobCount + '] "';
 
     console.log(

--- a/spec/pc-spec.js
+++ b/spec/pc-spec.js
@@ -1,35 +1,35 @@
 var rewire = require('rewire'),
-    PC = rewire('../lib/pc'),
-    Promise = require('bluebird');
+  PC = rewire('../lib/pc'),
+  Promise = require('bluebird');
 
-describe('Paper Cassette', function() {
+describe('Paper Cassette', function () {
 
-    var mockFs = {
-            writeFileAsync: jasmine.createSpy()
-        },
-        mockJenkins = function(){
-            return {
-                job: {
-                    list: function(){
-                        return Promise.try(function(){
-                            return [
-                                {name: 'Cactus'},
-                                {name: 'Gondor'},
-                                {name: 'Foobar'}
+  var mockFs = {
+        writeFileAsync: jasmine.createSpy()
+      },
+      mockJenkins = function () {
+          return {
+              job: {
+                  list: function () {
+                      return Promise.try(function () {
+                          return [
+                                { name: 'Cactus' },
+                                { name: 'Gondor' },
+                                { name: 'Foobar' }
                             ];
                         });
                     },
-                    config: function(jobName){
-                        return Promise.try(function(){
-                            switch (jobName) {
-                                case 'Cactus':
-                                    return '<xml>Cactus</xml>';
-                                case 'Gondor':
-                                    return '<xml>Gondor</xml>';
-                                case 'Foobar':
-                                    return '<xml>Foobar</xml>';
-                                default:
-                                    return undefined;
+                  config: function (jobName) {
+                      return Promise.try(function () {
+                          switch (jobName) {
+                              case 'Cactus':
+                                return '<xml>Cactus</xml>';
+                              case 'Gondor':
+                                return '<xml>Gondor</xml>';
+                              case 'Foobar':
+                                return '<xml>Foobar</xml>';
+                              default:
+                                return undefined;
                             }
                         });
                     }
@@ -37,65 +37,65 @@ describe('Paper Cassette', function() {
             };
         };
 
-    beforeEach(function(){
-        instrumentPC(mockJenkins, mockFs);
+  beforeEach(function () {
+      instrumentPC(mockJenkins, mockFs);
     });
 
-    it('should throw an exception if constructed without the proper options', function(){
+  it('should throw an exception if constructed without the proper options', function () {
 
-        expect(function(){
-            pc = new PC();
+      expect(function () {
+          pc = new PC();
         }).toThrow();
 
-        expect(function(){
-            pc = new PC({
+      expect(function () {
+          pc = new PC({
             });
         }).toThrow();
 
-        expect(function(){
-            pc = new PC({
-                files: '/foo'
+      expect(function () {
+          pc = new PC({
+              files: '/foo'
             });
         }).toThrow();
 
-        expect(function(){
-            pc = new PC({
-                files: '/foo',
-                jenkinsServer: 'myJenkins.roving.com'
+      expect(function () {
+          pc = new PC({
+              files: '/foo',
+              jenkinsServer: 'myJenkins.roving.com'
             });
         }).not.toThrow();
 
     });
 
-    describe('#unload', function(){
-        it('write all the available jenkins jobs to disk, in the directory specified', function(done){
-            pc = new PC({
-                files: '/foo',
-                jenkinsServer: 'cactus.roving.com'
+  describe('#unload', function () {
+      it('write all the available jenkins jobs to disk, in the directory specified', function (done) {
+          pc = new PC({
+              files: '/foo',
+              jenkinsServer: 'cactus.roving.com'
             });
-            expect(mockFs.writeFileAsync).not.toHaveBeenCalled();
-            pc.unload().then(function(){
-                expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
+          expect(mockFs.writeFileAsync).not.toHaveBeenCalled();
+          pc.unload().then(function () {
+              expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
                     '/foo/Cactus.xml', '<xml>Cactus</xml>'
                 );
-                expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
+              expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
                     '/foo/Gondor.xml', '<xml>Gondor</xml>'
                 );
-                expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
+              expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
                     '/foo/Foobar.xml', '<xml>Foobar</xml>'
                 );
-                expect(mockFs.writeFileAsync).not.toHaveBeenCalledWith(
+              expect(mockFs.writeFileAsync).not.toHaveBeenCalledWith(
                     '/foo/SmallBets.xml', '<xml>SmallBets</xml>'
                 );
-                done();
+              done();
             });
         });
     });
 });
 
 function instrumentPC(mockedJenkinsApi, mockedFsApi) {
-    PC.__set__({
-        jenkins: mockedJenkinsApi,
-        fs: mockedFsApi
+  PC.__set__({
+      jenkins: mockedJenkinsApi,
+      fs: mockedFsApi
     });
 }

--- a/spec/pc-spec.js
+++ b/spec/pc-spec.js
@@ -49,6 +49,7 @@ describe('Paper Cassette', function () {
   });
 
   it('should throw an exception if constructed without the proper options', function () {
+    var pc;
     expect(function () {
       pc = new PC();
     }).toThrow();
@@ -69,12 +70,13 @@ describe('Paper Cassette', function () {
         files: '/foo',
         jenkinsServer: 'myJenkins.roving.com',
       });
+      expect(pc).not.toBe(null);
     }).not.toThrow();
   });
 
   describe('#unload', function () {
     it('write all the available jenkins jobs to disk, in the directory specified', function (done) {
-      pc = new PC({
+      var pc = new PC({
         files: '/foo',
         jenkinsServer: 'cactus.roving.com',
       });

--- a/spec/pc-spec.js
+++ b/spec/pc-spec.js
@@ -5,7 +5,7 @@ var Promise = require('bluebird');
 describe('Paper Cassette', function () {
 
   var mockFs = {
-    writeFileAsync: jasmine.createSpy()
+    writeFileAsync: jasmine.createSpy(),
   };
 
   var mockJenkins = function () {
@@ -16,7 +16,7 @@ describe('Paper Cassette', function () {
             return [
               { name: 'Cactus' },
               { name: 'Gondor' },
-              { name: 'Foobar' }
+              { name: 'Foobar' },
             ];
           });
         },
@@ -33,8 +33,8 @@ describe('Paper Cassette', function () {
                 return undefined;
             }
           });
-        }
-      }
+        },
+      },
     };
   };
 
@@ -55,14 +55,14 @@ describe('Paper Cassette', function () {
 
     expect(function () {
       pc = new PC({
-        files: '/foo'
+        files: '/foo',
       });
     }).toThrow();
 
     expect(function () {
       pc = new PC({
         files: '/foo',
-        jenkinsServer: 'myJenkins.roving.com'
+        jenkinsServer: 'myJenkins.roving.com',
       });
     }).not.toThrow();
 
@@ -72,7 +72,7 @@ describe('Paper Cassette', function () {
     it('write all the available jenkins jobs to disk, in the directory specified', function (done) {
       pc = new PC({
         files: '/foo',
-        jenkinsServer: 'cactus.roving.com'
+        jenkinsServer: 'cactus.roving.com',
       });
       expect(mockFs.writeFileAsync).not.toHaveBeenCalled();
       pc.unload().then(function () {
@@ -97,6 +97,6 @@ describe('Paper Cassette', function () {
 function instrumentPC(mockedJenkinsApi, mockedFsApi) {
   PC.__set__({
     jenkins: mockedJenkinsApi,
-    fs: mockedFsApi
+    fs: mockedFsApi,
   });
 }

--- a/spec/pc-spec.js
+++ b/spec/pc-spec.js
@@ -37,6 +37,13 @@ describe('Paper Cassette', function () {
     };
   };
 
+  function instrumentPC(mockedJenkinsApi, mockedFsApi) {
+    PC.__set__({
+      jenkins: mockedJenkinsApi,
+      fs: mockedFsApi,
+    });
+  }
+
   beforeEach(function () {
     instrumentPC(mockJenkins, mockFs);
   });
@@ -90,10 +97,3 @@ describe('Paper Cassette', function () {
     });
   });
 });
-
-function instrumentPC(mockedJenkinsApi, mockedFsApi) {
-  PC.__set__({
-    jenkins: mockedJenkinsApi,
-    fs: mockedFsApi,
-  });
-}

--- a/spec/pc-spec.js
+++ b/spec/pc-spec.js
@@ -3,7 +3,6 @@ var PC = rewire('../lib/pc');
 var Promise = require('bluebird');
 
 describe('Paper Cassette', function () {
-
   var mockFs = {
     writeFileAsync: jasmine.createSpy(),
   };
@@ -43,7 +42,6 @@ describe('Paper Cassette', function () {
   });
 
   it('should throw an exception if constructed without the proper options', function () {
-
     expect(function () {
       pc = new PC();
     }).toThrow();
@@ -65,7 +63,6 @@ describe('Paper Cassette', function () {
         jenkinsServer: 'myJenkins.roving.com',
       });
     }).not.toThrow();
-
   });
 
   describe('#unload', function () {

--- a/spec/pc-spec.js
+++ b/spec/pc-spec.js
@@ -1,101 +1,102 @@
-var rewire = require('rewire'),
-  PC = rewire('../lib/pc'),
-  Promise = require('bluebird');
+var rewire = require('rewire');
+var PC = rewire('../lib/pc');
+var Promise = require('bluebird');
 
 describe('Paper Cassette', function () {
 
   var mockFs = {
-        writeFileAsync: jasmine.createSpy()
-      },
-      mockJenkins = function () {
-          return {
-              job: {
-                  list: function () {
-                      return Promise.try(function () {
-                          return [
-                                { name: 'Cactus' },
-                                { name: 'Gondor' },
-                                { name: 'Foobar' }
-                            ];
-                        });
-                    },
-                  config: function (jobName) {
-                      return Promise.try(function () {
-                          switch (jobName) {
-                              case 'Cactus':
-                                return '<xml>Cactus</xml>';
-                              case 'Gondor':
-                                return '<xml>Gondor</xml>';
-                              case 'Foobar':
-                                return '<xml>Foobar</xml>';
-                              default:
-                                return undefined;
-                            }
-                        });
-                    }
-                }
-            };
-        };
+    writeFileAsync: jasmine.createSpy()
+  };
+
+  var mockJenkins = function () {
+    return {
+      job: {
+        list: function () {
+          return Promise.try(function () {
+            return [
+              { name: 'Cactus' },
+              { name: 'Gondor' },
+              { name: 'Foobar' }
+            ];
+          });
+        },
+        config: function (jobName) {
+          return Promise.try(function () {
+            switch (jobName) {
+              case 'Cactus':
+                return '<xml>Cactus</xml>';
+              case 'Gondor':
+                return '<xml>Gondor</xml>';
+              case 'Foobar':
+                return '<xml>Foobar</xml>';
+              default:
+                return undefined;
+            }
+          });
+        }
+      }
+    };
+  };
 
   beforeEach(function () {
-      instrumentPC(mockJenkins, mockFs);
-    });
+    instrumentPC(mockJenkins, mockFs);
+  });
 
   it('should throw an exception if constructed without the proper options', function () {
 
-      expect(function () {
-          pc = new PC();
-        }).toThrow();
+    expect(function () {
+      pc = new PC();
+    }).toThrow();
 
-      expect(function () {
-          pc = new PC({
-            });
-        }).toThrow();
+    expect(function () {
+      pc = new PC({
+      });
+    }).toThrow();
 
-      expect(function () {
-          pc = new PC({
-              files: '/foo'
-            });
-        }).toThrow();
+    expect(function () {
+      pc = new PC({
+        files: '/foo'
+      });
+    }).toThrow();
 
-      expect(function () {
-          pc = new PC({
-              files: '/foo',
-              jenkinsServer: 'myJenkins.roving.com'
-            });
-        }).not.toThrow();
+    expect(function () {
+      pc = new PC({
+        files: '/foo',
+        jenkinsServer: 'myJenkins.roving.com'
+      });
+    }).not.toThrow();
 
-    });
+  });
 
   describe('#unload', function () {
-      it('write all the available jenkins jobs to disk, in the directory specified', function (done) {
-          pc = new PC({
-              files: '/foo',
-              jenkinsServer: 'cactus.roving.com'
-            });
-          expect(mockFs.writeFileAsync).not.toHaveBeenCalled();
-          pc.unload().then(function () {
-              expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
-                    '/foo/Cactus.xml', '<xml>Cactus</xml>'
-                );
-              expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
-                    '/foo/Gondor.xml', '<xml>Gondor</xml>'
-                );
-              expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
-                    '/foo/Foobar.xml', '<xml>Foobar</xml>'
-                );
-              expect(mockFs.writeFileAsync).not.toHaveBeenCalledWith(
-                    '/foo/SmallBets.xml', '<xml>SmallBets</xml>'
-                );
-              done();
-            });
-        });
+    it('write all the available jenkins jobs to disk, in the directory specified', function (done) {
+      pc = new PC({
+        files: '/foo',
+        jenkinsServer: 'cactus.roving.com'
+      });
+      expect(mockFs.writeFileAsync).not.toHaveBeenCalled();
+      pc.unload().then(function () {
+        expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
+          '/foo/Cactus.xml', '<xml>Cactus</xml>'
+        );
+        expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
+          '/foo/Gondor.xml', '<xml>Gondor</xml>'
+        );
+        expect(mockFs.writeFileAsync).toHaveBeenCalledWith(
+          '/foo/Foobar.xml', '<xml>Foobar</xml>'
+        );
+        expect(mockFs.writeFileAsync).not.toHaveBeenCalledWith(
+          '/foo/SmallBets.xml', '<xml>SmallBets</xml>'
+        );
+        done();
+      });
     });
+  });
 });
 
 function instrumentPC(mockedJenkinsApi, mockedFsApi) {
   PC.__set__({
-      jenkins: mockedJenkinsApi,
-      fs: mockedFsApi
-    });
+    jenkins: mockedJenkinsApi,
+    fs: mockedFsApi
+  });
 }


### PR DESCRIPTION
![Lint free or die. Why so emo?](http://2.bp.blogspot.com/-J3gs65QILOw/TeQb8BUX2eI/AAAAAAAAA8c/M1Wkl_kfacQ/s1600/Moose-Parks-Plate-web.jpg)
# Overview

These changes, if accepted, make it so that https://github.com/jedcn/jenkins-pc-load-letter/pull/1 passes lint.
## Methodology

I noticed you had `npm run lint` setup, so I:
1. Ran an `npm i`
2. Ran an `npm test`
3. Saw that tests passed
4. Started fixing lint problems
5. Kept the tests passing

..and here we are.
## How did we get here?

The first thing I did was add a `--fix` flag to eslint. It corrected over a hundred errors by itself. :heart:

The next thing I did was identify the parts of the eslint config that _demanded_ es6 features and disabled them. **A decision is looming: should this project work in ES5? Or ES6?** Unless you add a transpiler step, I think you're looking at ES5. Until then, I turned off all of the es6 specific rules we were violating. See a285a89. I saved this commit for last.

Oh, http://eslint.org/docs/rules/func-names.html is a doozy. I turned it off because I don't write that way.. and it seems that you don't, but perhaps we want to put it on. It's not to do with es6.

Then I went through everything else. line by line. I didn't do anything too crazy. But I also kept things limited to a single commit for clarity.
